### PR TITLE
Add Awesome OpenTofu

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4039,3 +4039,9 @@ sources:
     files:
       README.md:
         index: true
+  virtualroot/awesome-opentofu:
+    category: DevOps
+    default_branch: main
+    files:
+      README.md:
+        index: true


### PR DESCRIPTION
Add `awesome-opentofu` to `DevOps` category.

OpenTofu is an Open-source and community-driven tool that lets you define infrastructure as code.