### PR TITLE
config: comment out `awesome-kotlin`

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2819,13 +2819,13 @@ sources:
         options:
           max_heading_level: 1
           is_parse_category: false
-  KotlinBy/awesome-kotlin:
-    default_branch: readme
-    files:
-      README.md:
-        index: true
-        options:
-          max_heading_level: 2
+  # Heapy/awesome-kotlin:
+  #   default_branch: readme
+  #   files:
+  #     README.md:
+  #       index: true
+  #       options:
+  #         max_heading_level: 2
   alexk111/awesome-bitcoin-payment-processors:
     files:
       README.md:


### PR DESCRIPTION
The `awesome-kotlin` repo redirects to a new url, but it doesn't look like it is in a format that can be parsed, because it is built systematically.

I have updated the reference in the commented out section, in case someone can find how to make it work.