### PR TITLE
Update repository name from hobbyquaker to rhizomatics

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2278,7 +2278,7 @@ sources:
         options:
           type: table
 
-  hobbyquaker/awesome-mqtt:
+  rhizomatics/awesome-mqtt:
     category: Miscellaneous
     default_branch: master
     files:


### PR DESCRIPTION
Replacing the old repo with broken links with cleaned up fork using awesome-lint in GitHub actions to keep it clean