### PR TITLE
Update config.yml - multiple links down

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1052,6 +1052,12 @@ sources:
     files:
       README.md:
         index: true
+  clutcher/awesome_jetbrains_plugins:
+    category: Editors
+    default_branch: main
+    files:
+      README.md:
+        index: true
   sindresorhus/awesome-scifi:
     category: Entertainment
     default_branch: main


### PR DESCRIPTION
This PR includes small updates to keep the list accurate and up to date:

- Updated awesome-leading-and-managing with a new maintainer
- Renamed the default branch for awesome-tmux (fix #88)
- Removed shime/creative-commons-media, as the repository no longer exists
- Removed Awesome-Windows/Awesome, as the repository is no longer available
- Updated repository ownership for awesome-mqtt (close #86)
- Add awesome-build123d repository (close #66)
- Add awesome-cli-apps-in-a-csv repository (close #54)
- Add awesome_jetbrains_plugins (close #51)