### PR TITLE
Add Atlas awesome lists

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,54 @@ site:
   description:
     "We track over 500 awesome list updates, and you can also subscribe to daily or weekly updates via RSS or News Letter."
 sources:
+  dapollonsky/marketing-ai-stack:
+    category: Artificial Intelligence
+    default_branch: main
+    files:
+      README.md:
+        index: true
+  dapollonsky/gtm-ai-stack:
+    category: Artificial Intelligence
+    default_branch: main
+    files:
+      README.md:
+        index: true
+  soarsh/awesome-subreddits:
+    category: Miscellaneous
+    default_branch: main
+    files:
+      README.md:
+        index: true
+  soarsh/awesome-developer-tools-subreddits:
+    category: Development Environment
+    default_branch: main
+    files:
+      README.md:
+        index: true
+  soarsh/awesome-fintech-subreddits:
+    category: Finance
+    default_branch: main
+    files:
+      README.md:
+        index: true
+  soarsh/awesome-b2b-saas-subreddits:
+    category: Business
+    default_branch: main
+    files:
+      README.md:
+        index: true
+  soarsh/awesome-ecommerce-subreddits:
+    category: Business
+    default_branch: main
+    files:
+      README.md:
+        index: true
+  soarsh/awesome-healthtech-subreddits:
+    category: Health and Social Science
+    default_branch: main
+    files:
+      README.md:
+        index: true
   Piebald-AI/awesome-gemini-cli:
     category: Agentic AI
     default_branch: main


### PR DESCRIPTION
Adds eight Atlas-owned awesome lists to `config.yml` so Track Awesome List can follow their README updates.

Categories used:
- `dapollonsky/marketing-ai-stack` - Artificial Intelligence
- `dapollonsky/gtm-ai-stack` - Artificial Intelligence
- `soarsh/awesome-subreddits` - Miscellaneous
- `soarsh/awesome-developer-tools-subreddits` - Development Environment
- `soarsh/awesome-fintech-subreddits` - Finance
- `soarsh/awesome-b2b-saas-subreddits` - Business
- `soarsh/awesome-ecommerce-subreddits` - Business
- `soarsh/awesome-healthtech-subreddits` - Health and Social Science

Validation: `ruby -e 'require "yaml"; YAML.load_file("config.yml")'` succeeds.