### PR TITLE
Add seoulstart/awesome-living-in-korea

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2081,6 +2081,12 @@ sources:
     files:
       README.md:
         index: true
+  seoulstart/awesome-living-in-korea:
+    category: Miscellaneous
+    default_branch: main
+    files:
+      README.md:
+        index: true
   burningtree/awesome-json:
     category: Miscellaneous
     default_branch: master


### PR DESCRIPTION
Adds [seoulstart/awesome-living-in-korea](https://github.com/seoulstart/awesome-living-in-korea) to the tracked sources under **Miscellaneous**.

**What it is:** A curated awesome-list of resources for foreign residents in Korea — government portals (HiKorea, NHIS, NTS, NPS, EPS), visa guides, housing, healthcare, taxes, work, and Korean language. Available in 6 languages (EN, KO, VI, FIL, RU, ZH).

**Notes:**
- `awesome-lint` clean
- Default branch: `main`
- CC-BY-4.0 license
- Maintained actively (recent commits)

Thanks for running trackawesomelist — it's a great service for the awesome ecosystem.