### PR TITLE
Add Awesome iOS Pay-Once Apps

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4236,3 +4236,9 @@ sources:
     files:
       README.md:
         index: true
+  alice51849/awesome-ios-pay-once:
+    category: Platforms
+    default_branch: master
+    files:
+      README.md:
+        index: true


### PR DESCRIPTION
Adds `alice51849/awesome-ios-pay-once` to the Platforms category.

The list curates iPhone and iPad apps with a genuine one-time purchase or lifetime unlock, includes direct App Store links, accepts factual contributions, uses CC0, and clearly discloses that Lumi Studio maintains it and develops some listed apps. It also includes established apps from other developers rather than presenting a self-ranking.

The repository uses `master`, and `README.md` is the indexed file.